### PR TITLE
Make Posting.units optional

### DIFF
--- a/beancount-stubs/core/data.pyi
+++ b/beancount-stubs/core/data.pyi
@@ -106,7 +106,7 @@ class Balance:
 
 class Posting:
     account: Account
-    units: Amount
+    units: Optional[Amount]
     cost: Optional[Union[Cost, CostSpec]]
     price: Optional[Amount]
     flag: Optional[Flag]


### PR DESCRIPTION
Beancount v2 doesn't specify it as such, but it behaves this way, and code like [smart-importer](https://github.com/beancount/smart_importer/blob/9c9ec14c0c6b3e01d8ad3957901b05b0f82cc878/smart_importer/entries.py#L13) treats it this way. Amount is also optional in beancount v3.