### PR TITLE
Add missing `TxnPosting` to `compute_postings_balance`

### DIFF
--- a/beancount-stubs/core/realization.pyi
+++ b/beancount-stubs/core/realization.pyi
@@ -75,5 +75,5 @@ def dump_balances(
     file: Any | None = ...,
 ) -> str | None: ...
 def compute_postings_balance(
-    txn_postings: Iterable[Posting | Directive],
+    txn_postings: Iterable[Posting | TxnPosting | Directive],
 ) -> Inventory: ...


### PR DESCRIPTION
The function explicitly takes a list that can contain `Posting`s and/or `TxnPosting`s (or anything else, which is skipped).

https://github.com/beancount/beancount/blob/be13ab359987947eb0f8d241fde55adc65cb4dbc/beancount/core/realization.py#L690-L694